### PR TITLE
Updated the interface add IECR20 to the ETH token.

### DIFF
--- a/contracts/Interfaces.sol
+++ b/contracts/Interfaces.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-interface IBEP20 {
+interface ITOKEN20 {
   /**
    * @dev Returns the amount of tokens in existence.
    */
@@ -91,6 +91,11 @@ interface IBEP20 {
    */
   event Approval(address indexed owner, address indexed spender, uint256 value);
 }
+
+interface IBEP20 is ITOKEN20 {}
+
+interface IERC20 is ITOKEN20 {}
+
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/contracts/XIL_ETH.sol
+++ b/contracts/XIL_ETH.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./Interfaces.sol";
 
-contract XIL_ETH is Context, IBEP20, Ownable {
+contract XIL_ETH is Context, IERC20, Ownable {
     
     using SafeMath for uint256;
     


### PR DESCRIPTION
The minor change to update ETH token to reference ECR20 rather than BEP20, using the same base interface with named references. This has not changed the functionality of the code, just updating the interface name for ETH maxi contract reviews.